### PR TITLE
fix(links): point YouTube link at @designgoldmedia handle (#36)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,7 +33,7 @@
         <ul>
           <li><a href="https://podcasts.apple.com/gb/podcast/design-gold/id1460573900" target="_blank">Apple Podcasts</a></li>
           <li><a href="https://open.spotify.com/show/4ehtIPWPm1RcRdKKZrfjaJ" target="_blank">Spotify</a></li>
-          <li><a href="https://www.youtube.com/@designgold" target="_blank">YouTube</a></li>
+          <li><a href="https://www.youtube.com/@designgoldmedia" target="_blank">YouTube</a></li>
           <li><a href="https://pca.st/podcast/design-gold" target="_blank">Pocket Casts</a></li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ layout: default
   <p>Listen on
     <a href="https://podcasts.apple.com/gb/podcast/design-gold/id1460573900" target="_blank"><img src="img/applepodcast.svg" alt="Apple Podcasts" class="listen-icon"> Apple Podcasts</a>,
     <a href="https://open.spotify.com/show/4ehtIPWPm1RcRdKKZrfjaJ" target="_blank"><img src="img/spotify.svg" alt="Spotify" class="listen-icon"> Spotify</a>,
-    <a href="https://www.youtube.com/@designgold" target="_blank"><img src="img/youtube.svg" alt="YouTube" class="listen-icon"> YouTube</a>,
+    <a href="https://www.youtube.com/@designgoldmedia" target="_blank"><img src="img/youtube.svg" alt="YouTube" class="listen-icon"> YouTube</a>,
     <a href="https://pca.st/podcast/design-gold" target="_blank"><img src="img/pocketcasts.svg" alt="Pocket Casts" class="listen-icon"> Pocket Casts</a>
     <!-- ,<a href="{{ site.baseurl }}/feed.xml">RSS</a> -->
   </p>


### PR DESCRIPTION
## Summary

The YouTube link on the homepage (`index.html`) and in the shared footer (`_includes/footer.html`) pointed at `https://www.youtube.com/@designgold` — that handle 404s. The active channel is `@designgoldmedia`.

Fixes #36

## Test plan

- [x] `grep youtube.com` returns the two updated paths only — no other stale references.